### PR TITLE
workaround for build fail

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,10 +3,10 @@
   "version": "1.0.0",
   "description": "Grafana Data Source Backend Plugin Template",
   "scripts": {
-    "build": "grafana-toolkit plugin:build",
-    "test": "grafana-toolkit plugin:test",
-    "dev": "grafana-toolkit plugin:dev",
-    "watch": "grafana-toolkit plugin:dev --watch"
+    "build": "rm -rf node_modules/@grafana/data/node_modules; grafana-toolkit plugin:build",
+    "test": "rm -rf node_modules/@grafana/data/node_modules; grafana-toolkit plugin:test",
+    "dev": "rm -rf node_modules/@grafana/data/node_modules; grafana-toolkit plugin:dev",
+    "watch": "rm -rf node_modules/@grafana/data/node_modules; grafana-toolkit plugin:dev --watch"
   },
   "author": "Grafana Labs",
   "license": "Apache-2.0",


### PR DESCRIPTION
Hi :wave: , this is a workaround for these issues:
* https://github.com/grafana/grafana/issues/28395
* https://github.com/grafana/grafana-starter-datasource-backend/issues/16

This change was suggested here https://github.com/grafana/grafana/issues/28395#issuecomment-714715586

We think that the best way to solve is to fix the type error issues, but this workaround works

Please let me know if there are any questions or suggestions on this fix