### PR TITLE
Update backend datasource patterns:

### DIFF
--- a/pkg/main.go
+++ b/pkg/main.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend/datasource"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
+	"github.com/grafana/grafana-starter-datasource-backend/pkg/plugin"
 )
 
 func main() {
@@ -16,7 +17,7 @@ func main() {
 	// from Grafana to create different instances of SampleDatasource (per datasource
 	// ID). When datasource configuration changed Dispose method will be called and
 	// new datasource instance created using NewSampleDatasource factory.
-	if err := datasource.Manage("myorgid-simple-backend-datasource", NewSampleDatasource, datasource.ManageOpts{}); err != nil {
+	if err := datasource.Manage("myorgid-simple-backend-datasource", plugin.NewSampleDatasource, datasource.ManageOpts{}); err != nil {
 		log.DefaultLogger.Error(err.Error())
 		os.Exit(1)
 	}

--- a/pkg/plugin/sample-plugin.go
+++ b/pkg/plugin/sample-plugin.go
@@ -1,4 +1,4 @@
-package main
+package plugin
 
 import (
 	"context"

--- a/pkg/plugin/sample-plugin_test.go
+++ b/pkg/plugin/sample-plugin_test.go
@@ -1,0 +1,30 @@
+package plugin_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/grafana/grafana-starter-datasource-backend/pkg/plugin"
+)
+
+// This is where the tests for the datasource backend live.
+func TestQueryData(t *testing.T) {
+	ds := plugin.SampleDatasource{}
+
+	resp, err := ds.QueryData(
+		context.Background(),
+		&backend.QueryDataRequest{
+			Queries: []backend.DataQuery{
+				{RefID: "A"},
+			},
+		},
+	)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if len(resp.Responses) != 1 {
+		t.Fatal("QueryData must return a response")
+	}
+}


### PR DESCRIPTION
The enterprise plugins team have some new plugin patterns that we'd like to encourage by adding them to the default project:

- Move plugin business logic to 'plugin' package to encourage cleaner testing
  and separation from main.
- Add some sample tests
- bump the SDK