### PR TITLE
Add tsconfig line for DataSourceVariableSupport

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "@grafana/toolkit/src/config/tsconfig.plugin.json",
   "include": ["src", "types"],
   "compilerOptions": {
+    "target": "es6",
     "rootDir": "./src",
     "baseUrl": "./src",
     "typeRoots": ["./node_modules/@types"]


### PR DESCRIPTION
For reasons that are still a bit mysterious to me, when working on [Template Variables for a new plugin](https://github.com/grafana/athena-datasource/pull/34) we tried to reuse the QueryEditor for query template variables with DataSourceVariableSupport and we hit the following error: 
`TypeError: class constructors must be invoked with 'new'` 

This error seems to go away when we add this line to our tsconfig. 🤷‍♀️ What's particularly confusing to me is that I didn't see any tsconfig errors in yarn watch or yarn build. Maybe someone better with typescript/es6 can better explain what's going on here, but I think we should probably add this to our template.