### PR TITLE
Update release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -119,7 +119,7 @@ jobs:
       - name: Lint plugin
         run: |
           git clone https://github.com/grafana/plugin-validator
-          pushd ./plugin-validator/cmd/plugincheck
+          pushd ./plugin-validator/pkg/cmd/plugincheck
           go install
           popd
           plugincheck ${{ steps.metadata.outputs.archive }}


### PR DESCRIPTION
The [`plugincheck`](https://github.com/grafana/plugin-validator/tree/master/pkg/cmd/plugincheck) package is under the `pkg/` directory now.