### PR TITLE
README: add deprecation notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,15 @@
+## ⚠️ Deprecated!
+
+**This repository is deprecated.** <br />
+A more up-to-date version of examples is available here: https://github.com/grafana/grafana-plugin-examples
+
+**Available examples:**
+- [datasource-basic](https://github.com/grafana/grafana-plugin-examples/blob/master/examples/datasource-basic) - demonstrates how to build a basic data source plugin with a backend
+- [datasource-http](https://github.com/grafana/grafana-plugin-examples/blob/master/examples/datasource-http) - demonstrates how to query data from HTTP-based APIs.
+- [datasource-streaming-websocket](https://github.com/grafana/grafana-plugin-examples/blob/master/examples/datasource-streaming-websocket) - demonstrates how to create an event-based data source plugin using RxJS and web sockets.
+
+---
+
 # Grafana Data Source Backend Plugin Template
 
 [![Build](https://github.com/grafana/grafana-starter-datasource-backend/workflows/CI/badge.svg)](https://github.com/grafana/grafana-datasource-backend/actions?query=workflow%3A%22CI%22)


### PR DESCRIPTION
### What changed?

Added a deprecation notice to the README and linked the new `grafana/grafana-plugin-examples` repo as the place to go to.

[Check out the updated README](https://github.com/grafana/grafana-starter-datasource-backend/blob/leventebalogh/add-deprecation-notice/README.md)

**Preview:** 
<img width="1042" alt="Screenshot 2022-03-04 at 10 31 36" src="https://user-images.githubusercontent.com/9974811/156737636-d9035cc9-76df-4016-ae14-383f18ce3697.png">

